### PR TITLE
Fix command injection vulnerabiltiy

### DIFF
--- a/lib/helpers/run-git-command.js
+++ b/lib/helpers/run-git-command.js
@@ -1,27 +1,20 @@
-var exec = require('child_process').exec
-var execSync = require('child_process').execSync
+var exec = require('child_process').execFile
+var execSync = require('child_process').execFileSync
 var path = require('path')
 var removeEmptyLines = require('./remove-empty-lines')
 
 module.exports = function (gitWorkTree, command, callback) {
-  var gitCommand = gitWorkTree
-    ? [
-      'git',
-      '--git-dir=' + path.join(gitWorkTree, '.git'),
-      '--work-tree=' + gitWorkTree,
-      command
-    ].join(' ')
-    : [
-      'git',
-      command
-    ].join(' ')
+  var gitCommand = gitWorkTree ?
+  ['--git-dir', path.join(gitWorkTree),
+  '--work-tree', gitWorkTree,
+  ...command.split(' ') ] : command.split(' ')
 
   if (callback) {
-    exec(gitCommand, function (err, stdout) {
+    exec('git', gitCommand, function (err, stdout) {
       if (err) { return callback(err) }
       callback(null, removeEmptyLines(stdout))
     })
   } else {
-    return removeEmptyLines('' + execSync(gitCommand))
+    return removeEmptyLines('' + execSync('git', gitCommand))
   }
 }


### PR DESCRIPTION
I've replaced `exec`/`execSync` with execFile/execFileSync and modified the source code accordingly. The POC code for this vulnerability now throws an error: 
```

fatal: not a git repository: '& echo vulnerable > create.txt &'
Thrown:
Error: Command failed: git --git-dir & echo vulnerable > create.txt & --work-tree & echo vulnerable > create.txt & rev-parse HEAD
fatal: not a git repository: '& echo vulnerable > create.txt &'
```